### PR TITLE
fix header dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,11 @@ MOD_LUA += mod_lua_bytes.o
 MOD_LUA += mod_lua_stream.o
 MOD_LUA += mod_lua_val.o
 
+AEROSPIKE-HEADERS = $(patsubst $(SOURCE_INCL)/aerospike/%.h,%.h,$(wildcard $(SOURCE_INCL)/aerospike/*.h))
+
+HEADERS =
+HEADERS += $(AEROSPIKE-HEADERS:%=$(TARGET_INCL)/aerospike/%)
+
 ###############################################################################
 ##  MAIN TARGETS                                                             ##
 ###############################################################################
@@ -90,7 +95,7 @@ MOD_LUA += mod_lua_val.o
 all: build prepare
 
 .PHONY: prepare
-prepare: $(TARGET_INCL)/aerospike/*.h
+prepare: $(HEADERS)
 
 .PHONY: build 
 build: libmod_lua


### PR DESCRIPTION
The wildcard dependency in prepare doesn't work (at least not with GNU make 3.82):

```
make[1]: Entering directory `/home/bene/projects/remerge/aerospike-client-c/modules/mod-lua'
make[1]: *** No rule to make target `target/Linux-x86_64/include/aerospike/*.h', needed by `prepare'.  Stop.
make[1]: Leaving directory `/home/bene/projects/remerge/aerospike-client-c/modules/mod-lua'
make: *** [MOD_LUA-make-prepare] Error 2
```

This patch fixes the issue.
