### PR TITLE
free after lua_pushlstring

### DIFF
--- a/src/main/mod_lua_bytes.c
+++ b/src/main/mod_lua_bytes.c
@@ -1652,6 +1652,7 @@ static int mod_lua_bytes_get_string(lua_State * l)
 	val[len] = '\0';
 	
 	lua_pushlstring(l, val, len);
+	free(val);
 	return 1;
 }
 


### PR DESCRIPTION
Hi,

we encoutered memory leak (sadly in production :worried:) and we discovered that it is not in our code but in the `bytes.get_string()` (http://www.aerospike.com/docs/udf/api/bytes.html)
Based on the `lua_pushlstring` reference http://www.lua.org/pil/24.2.1.html,

> Lua either makes an internal copy or reuses one. Therefore, you can free or modify your buffer as soon as these functions return.

we _can free_ the string, but I think we really should :wink: 

The fix is tested and is working as expected.
